### PR TITLE
Call emitRangeSelected() on reset() with null values for start and end

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![ngx-daterange](https://res.cloudinary.com/alsoicode/image/upload/v1542168886/ngx-daterange/ngx-daterange.png)
 
-Current version: 1.0.7
+Current version: 1.0.9
 
 Here's a minimal example of ngx-daterange in action, showing positioning on the left, right and using custom templating: https://ngx-daterange.netlify.com/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange-sample-application",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/modules/ngx-daterange/package.json
+++ b/src/modules/ngx-daterange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Date-Range Selector for Angular",
   "main": "index.js",
   "scripts": {

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
@@ -188,19 +188,9 @@ export class DateRangePickerComponent implements OnInit {
     }
   }
 
-  emitRangeSelected(): void {
-    let data: IDateRange;
-
-    if (this.options.singleCalendar) {
-      data = {
-        start: this.fromDate,
-      };
-    }
-    else {
-      data = {
-        start: this.fromDate,
-        end: this.toDate,
-      };
+  emitRangeSelected(data?: IDateRange): void {
+    if (!data) {
+      data = this.options.singleCalendar ? { start: this.fromDate } : { start: this.fromDate, end: this.toDate };
     }
 
     this.rangeSelected.emit(data);
@@ -310,6 +300,9 @@ export class DateRangePickerComponent implements OnInit {
     this.fromDate = null;
     this.toDate = null;
     this.setRange();
+
+    const data: IDateRange = this.options.singleCalendar ? { start: null } : { start: null, end: null };
+    this.emitRangeSelected(data);
 
     event.stopPropagation();
   }


### PR DESCRIPTION
Version bump to 1.0.9
Updated reset() event to call emitRangeSelected() with null values for start and end.