### PR TITLE
Bugfix/set to calendar ahead on same year future month

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![ngx-daterange](https://res.cloudinary.com/alsoicode/image/upload/v1542168886/ngx-daterange/ngx-daterange.png)
 
-Current version: 1.0.25
+Current version: 1.0.28
 
 Here's a minimal example of ngx-daterange in action, showing positioning on the left, right and using custom templating: https://ngx-daterange.netlify.app/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange-sample-application",
-  "version": "1.0.26",
+  "version": "1.0.28",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/modules/ngx-daterange/package.json
+++ b/src/modules/ngx-daterange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange",
-  "version": "1.0.26",
+  "version": "1.0.28",
   "description": "Date-Range Selector for Angular",
   "main": "index.js",
   "scripts": {

--- a/src/modules/ngx-daterange/src/components/calendar/calendar.component.ts
+++ b/src/modules/ngx-daterange/src/components/calendar/calendar.component.ts
@@ -72,7 +72,7 @@ export class CalendarComponent implements OnChanges {
         const month: number = currentValue.month();
         const year: number = currentValue.year();
 
-        if (year > this.year) {
+        if (year > this.year || (year === this.year && month > this.month)) {
           this.month = month;
           this.year = year;
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,9 @@
       "es2018",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
- "To" calendar will now be set to "From" calendar month/year if a future month is selected in the "From" calendar in the same year