### PR TITLE
bugfix / emitRangeSelected called incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![ngx-daterange](https://res.cloudinary.com/alsoicode/image/upload/v1542168886/ngx-daterange/ngx-daterange.png)
 
-Current version: 1.0.41
+Current version: 1.0.42
 
 Here's a minimal example of ngx-daterange in action, showing positioning on the left, right and using custom templating: https://ngx-daterange.netlify.app/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange-sample-application",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/modules/ngx-daterange/package.json
+++ b/src/modules/ngx-daterange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-daterange",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Date-Range Selector for Angular",
   "main": "index.js",
   "scripts": {

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
@@ -296,7 +296,13 @@ export class DateRangePickerComponent implements OnInit {
             isLeft,
           });
 
-          this.setFromToMonthYear(this.fromDate, this.toDate);
+          if (this.fromDate && this.toDate) {
+            this.setFromToMonthYear(this.fromDate, this.toDate);
+
+            if (!this.options.autoApply) {
+              this.emitRangeSelected();
+            }
+          }
         }
         else {
           // assume nothing - reset values
@@ -306,8 +312,6 @@ export class DateRangePickerComponent implements OnInit {
           target.focus();
         }
       }
-
-      this.emitRangeSelected();
     }
     catch (e) {
       console.error(e);


### PR DESCRIPTION
- Updated setDateFromInput to only call emitRangeSelected if both from and to dates exist AND autoApply is false
- Version bump to 1.0.42
- Updated version in README