### PR TITLE
Add disableInputDisplay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ Default value: `true`
 
 <hr/>
 
+### disableInputDisplay
+
+Set this to `true` if you want to apply the `disabled` attribute to the `input` element that renders the selected range (or single date value) of the DatePicker component. Unlike the `fromDate` or `toDate` `input` elements displayed above the calendars, which are _not_ affect by this option, enabling this option prevents the user from editing the displayed range/value, which can cause confusion as the edited value will not reflect the actual range/value of the component.
+
+Type: `boolean`
+
+Default value: `false`
+
+<hr/>
+
 ### format
 
 The format of the `range` value as displayed in the UI.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -47,11 +47,21 @@
       </form>
     </div>
   </div>
-  <div class="row">
+  <div class="row mb-4">
     <div class="col col-sm-2">
       <form enctype="application/x-www-form-urlencoded" role="form" >
         <fieldset>
           <date-range-picker [options]="singleFieldOptions" [parentFormGroup]="form" controlName="'singleField'" (rangeSelected)="onRangeSelected($event)"></date-range-picker>
+        </fieldset>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col col-sm-2">
+      <form enctype="application/x-www-form-urlencoded" role="form">
+        <fieldset>
+          <date-range-picker [options]="disableInputDisplayOptions" [parentFormGroup]="form" controlName="'disableInputDisplayField'" (rangeSelected)="onRangeSelected($event)"></date-range-picker>
+          <p>This datepicker has the &#8220;disableInputDisplay&#8221; feature set to true. The input field shown here is disabled, preventing manual editing, but still allowing the DatePicker to be used and displaying the selected range.</p>
         </fieldset>
       </form>
     </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -70,6 +70,15 @@ export class AppComponent implements OnInit {
     singleCalendar: true,
   }
 
+  disableInputDisplayOptions: IDateRangePickerOptions = {
+    disableInputDisplay: true,
+    format: 'MM/DD/YYYY',
+    icons: 'material',
+    labelText: 'Input Display Disabled',
+    minDate: moment().subtract(2, 'years'),
+    maxDate: moment().add(1, 'year')
+  };
+
   form: FormGroup = null;
 
   constructor (

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.scss
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.scss
@@ -2,6 +2,10 @@
   position: relative;
   border: none;
 
+  input.form-control[disabled] {
+    background-color: #fff;
+  }
+
   .dateRangePicker {
     background: #fff;
     border-radius: 9px;

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.spec.ts
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.spec.ts
@@ -108,6 +108,22 @@ describe('Testing DateRangePickerComponent', () => {
       expect(() => fixture.detectChanges()).toThrow();
     }));
 
+    it('should disable the input element if options.disableInputDisplay is true', waitForAsync(() => {
+      const options: IDateRangePickerOptions = Object.assign(simpleOptions, {
+        disableInputDisplay: true,
+        minDate: moment().subtract(1, 'month'),
+        maxDate: moment(),
+        singleCalendar: false,
+        preDefinedRanges: null,
+      });
+
+      component.options = options;
+      fixture.detectChanges();
+
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+      expect(input.disabled).toBeTrue();
+    }));
+
     describe('Pre-Defined Range Tests', () => {
       it('should throw an error if the range start value is after the range end value', waitForAsync(() => {
         const options: IDateRangePickerOptions = Object.assign(simpleOptions, {

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
@@ -146,7 +146,7 @@ export class DateRangePickerComponent implements OnInit {
 
     // add form control to parent form group
     const value = this.formatRangeAsString();
-    const control = new FormControl(value, this.options.validators);
+    const control = new FormControl({value, disabled: this.options.disableInputDisplay}, this.options.validators);
 
     if (this.options.disabled) {
       control.disable();

--- a/src/modules/ngx-daterange/src/constants/default-range-picker-options.ts
+++ b/src/modules/ngx-daterange/src/constants/default-range-picker-options.ts
@@ -6,6 +6,7 @@ export const defaultDateRangePickerOptions: IDateRangePickerOptions = {
   autoApply: true,
   clickOutsideAllowed: true,
   disabled: false,
+  disableInputDisplay: false,
   icons: 'default',
   format: defaultDateFormat,
   labelText: 'Date Range',

--- a/src/modules/ngx-daterange/src/interfaces/IDateRangePickerOptions.ts
+++ b/src/modules/ngx-daterange/src/interfaces/IDateRangePickerOptions.ts
@@ -8,6 +8,7 @@ export interface IDateRangePickerOptions {
   clickOutsideAllowed?: boolean;
   displayFormat?: string;
   disabled?: boolean;
+  disableInputDisplay?: boolean;
   format: string;
   icons?: 'default' | 'material' | 'font-awesome';
   labelText?: string;


### PR DESCRIPTION
This option applies the "disabled" attribute to the `input` field used to display the selected range. Unlike the `fromDate` and `toDate` input fields, which are _not_ affected by this option, manual edits to the `input` field used to display the selected range do not update the selected range of the component.