### PR TITLE
Avoid IE11 errors

### DIFF
--- a/src/modules/ngx-daterange/src/components/calendar/calendar.component.ts
+++ b/src/modules/ngx-daterange/src/components/calendar/calendar.component.ts
@@ -133,7 +133,7 @@ export class CalendarComponent implements OnChanges {
     const weeksRange = this.getWeeksRange(this.getWeekNumbers(monthRange));
     const weekList = [];
 
-    weeksRange.map(week => {
+    weeksRange?.map(week => {
       const daysList = [];
 
       Array.from(week.by('days')).forEach((day: momentNs.Moment) => {

--- a/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
+++ b/src/modules/ngx-daterange/src/components/datepicker/date-range-picker.component.ts
@@ -75,12 +75,12 @@ export class DateRangePickerComponent implements OnInit {
       }
       catch (error) {
         // IE / Edge
-        targetPathClassNames = event['path'].map(obj => obj.className);
+        targetPathClassNames = event['path']?.map(obj => obj.className);
       }
 
       let containerElementClassRoot = this.options.modal === true ? 'dateRangePickerModal' : 'dateRangePicker';
-      
-      const targetExistsInPath = targetPathClassNames.some(className => {
+
+      const targetExistsInPath = targetPathClassNames?.some(className => {
         if (typeof className === 'string') {
           return className && className.includes(containerElementClassRoot);
         }
@@ -210,11 +210,11 @@ export class DateRangePickerComponent implements OnInit {
     const tempFromDate = fromDate || this.fromDate || moment();
     const tempToDate = toDate || this.toDate || moment();
 
-    this.fromMonth = tempFromDate.get('month');
-    this.fromYear = tempFromDate.get('year');
+    this.fromMonth = tempFromDate?.get('month');
+    this.fromYear = tempFromDate?.get('year');
 
-    this.toMonth = tempToDate.get('month');
-    this.toYear = tempToDate.get('year');
+    this.toMonth = tempToDate?.get('month');
+    this.toYear = tempToDate?.get('year');
   }
 
   updateCalendar(): void {
@@ -293,7 +293,7 @@ export class DateRangePickerComponent implements OnInit {
     this.range = this.formatRangeAsString();
 
     if (this.parentFormGroup) {
-      const control = this.parentFormGroup.get(this.controlName);
+      const control = this.parentFormGroup?.get(this.controlName);
 
       if (control) {
         control.setValue(this.range);
@@ -351,13 +351,13 @@ export class DateRangePickerComponent implements OnInit {
 
     if (data.isLeft) {
       temp = moment([this.fromYear, this.fromMonth]).add(data.value, 'month');
-      this.fromMonth = temp.get('month');
-      this.fromYear = temp.get('year');
+      this.fromMonth = temp?.get('month');
+      this.fromYear = temp?.get('year');
     }
     else {
       temp = moment([this.toYear, this.toMonth]).add(data.value, 'month');
-      this.toMonth = temp.get('month');
-      this.toYear = temp.get('year');
+      this.toMonth = temp?.get('month');
+      this.toYear = temp?.get('year');
     }
   }
 
@@ -366,13 +366,13 @@ export class DateRangePickerComponent implements OnInit {
 
     if (data.isLeft) {
       temp = moment([this.fromYear, this.fromMonth]).add(data.value, 'year');
-      this.fromMonth = temp.get('month');
-      this.fromYear = temp.get('year');
+      this.fromMonth = temp?.get('month');
+      this.fromYear = temp?.get('year');
     }
     else {
       temp = moment([this.toYear, this.toMonth]).add(data.value, 'year');
-      this.toMonth = temp.get('month');
-      this.toYear = temp.get('year');
+      this.toMonth = temp?.get('month');
+      this.toYear = temp?.get('year');
     }
   }
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -19,20 +19,20 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/weak-map';
-// import 'core-js/es6/set';
+import 'core-js/es/symbol';
+import 'core-js/es/object';
+import 'core-js/es/function';
+import 'core-js/es/parse-int';
+import 'core-js/es/parse-float';
+import 'core-js/es/number';
+import 'core-js/es/math';
+import 'core-js/es/string';
+import 'core-js/es/date';
+import 'core-js/es/array';
+import 'core-js/es/regexp';
+import 'core-js/es/map';
+import 'core-js/es/weak-map';
+import 'core-js/es/set';
 
 /**
  * If the application will be indexed by Google Search, the following is required.


### PR DESCRIPTION
I'm using this package in an application that still requires support for IE11. These changes add the polyfills for the demo application and avoid runtime errors by using [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).